### PR TITLE
fix:サーバー起動時にフロントのオリジンからのアクセスを許可(CORS)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,9 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableCors({
+    origin: 'http://localhost:3000'
+  });
   await app.listen(5000);
 }
 bootstrap();


### PR DESCRIPTION
フロントでAPIを叩くときにブラウザでCORSエラーが生じたので指定のリンクのアクセス許可を行った。